### PR TITLE
Add nightly RPM builds for Gluster 4.1

### DIFF
--- a/nightly-rpm-builds.yml
+++ b/nightly-rpm-builds.yml
@@ -31,24 +31,6 @@
         - project: gluster_build-rpms
           block: false
           predefined-parameters:
-            GERRIT_BRANCH=release-3.10
-
-            CENTOS_VERSION=7
-
-            CENTOS_ARCH=x86_64
-    - trigger-builds:
-        - project: gluster_build-rpms
-          block: false
-          predefined-parameters:
-            GERRIT_BRANCH=release-3.10
-
-            CENTOS_VERSION=6
-
-            CENTOS_ARCH=x86_64
-    - trigger-builds:
-        - project: gluster_build-rpms
-          block: false
-          predefined-parameters:
             GERRIT_BRANCH=release-3.12
 
             CENTOS_VERSION=7
@@ -67,7 +49,16 @@
         - project: gluster_build-rpms
           block: false
           predefined-parameters:
-            GERRIT_BRANCH=release-4.0
+            GERRIT_BRANCH=release-4.1
+
+            CENTOS_VERSION=6
+
+            CENTOS_ARCH=x86_64
+    - trigger-builds:
+        - project: gluster_build-rpms
+          block: false
+          predefined-parameters:
+            GERRIT_BRANCH=release-4.1
 
             CENTOS_VERSION=7
 

--- a/scripts/nightly-builds/nightly-builds.sh
+++ b/scripts/nightly-builds/nightly-builds.sh
@@ -64,12 +64,23 @@ SRPM=$(rpmbuild --define 'dist .autobuild' --define "_srcrpmdir ${PWD}" \
     --define '_source_filedigest_algorithm 1' \
     -ts glusterfs-${VERSION}.tar.gz | cut -d' ' -f 2)
 
+MOCK_RPM_OPTS=''
+case "${CENTOS_VERSION}/${GIT_VERSION}" in
+    6/4*)
+        # CentOS-6 does not support server builds from Gluster 4.0 onwards
+        MOCK_RPM_OPTS='--without=server'
+    *)
+        # gnfs is not enabled by default, but our regression tests depend on it
+        MOCK_RPM_OPTS='--with=gnfs'
+        ;;
+esac
+
 # do the actual RPM build in mock
 # TODO: use a CentOS Storage SIG buildroot
 RESULTDIR=/srv/gluster/nightly/${GERRIT_BRANCH}/${CENTOS_VERSION}/${CENTOS_ARCH}
 /usr/bin/mock \
     --root epel-${CENTOS_VERSION}-${CENTOS_ARCH} \
-    --with=gnfs \
+    ${MOCK_RPM_OPTS} \
     --resultdir ${RESULTDIR} \
     --rebuild ${SRPM}
 


### PR DESCRIPTION
While adding these, drop the unmaintained versions 3.10 and 4.0.
It seems that 4.0 was not build for CentOS-6 yet, added the suitable
parameters to build the RPMs with mock.