### PR TITLE
gluster-block: add centos CI files for glusto tests 

### DIFF
--- a/scripts/gluster-block/get-glusto-logs.sh
+++ b/scripts/gluster-block/get-glusto-logs.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -x
+set +e
+
+host=$(cat hosts | grep ansible_host | head -n 1 | awk '{split($2, a, "="); print a[2]}')
+ANSIBLE_HOST_KEY_CHECKING=False $HOME/env/bin/ansible-playbook -i hosts scripts/gluster-block/get-logs.yml || true
+scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@$host:/root/gluster-logs.gz $WORKSPACE/ || true
+scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@$host:/tmp/glustomain.log $WORKSPACE/ || true

--- a/scripts/gluster-block/get-logs.yml
+++ b/scripts/gluster-block/get-logs.yml
@@ -1,0 +1,31 @@
+- hosts: gluster_nodes[0]
+  tasks:
+  - name: Create a folder for each server
+    file:
+      state: directory
+      path: "/root/gluster-logs/{{ hostvars[item]['inventory_hostname_short'] }}-{{ hostvars[item]['ansible_host'] }}"
+    with_items: "{{ groups['gluster_nodes'][1:] }}"
+
+- hosts: gluster_nodes[1:]
+  tasks:
+  - name: Copy gluster logs
+    synchronize:
+      src: /var/log/glusterfs
+      dest: "/root/gluster-logs/{{ ansible_hostname }}-{{ ansible_eth0.ipv4.address }}"
+      mode: pull
+    delegate_to: "{{ groups['gluster_nodes'][0] }}"
+
+  - name: Copy gluster-block logs
+    synchronize:
+      src: /var/log/gluster-block
+      dest: "/root/gluster-logs/{{ ansible_hostname }}-{{ ansible_eth0.ipv4.address }}"
+      mode: pull
+    delegate_to: "{{ groups['gluster_nodes'][0] }}"
+
+- hosts: gluster_nodes[0]
+  tasks:
+  - name: Archive the directory
+    archive:
+      path: "/root/gluster-logs"
+      format: gz
+dest: "/root/gluster-logs.gz"

--- a/scripts/gluster-block/gluster_block_glusto_tests_config.yml.j2
+++ b/scripts/gluster-block/gluster_block_glusto_tests_config.yml.j2
@@ -1,0 +1,31 @@
+log_level: DEBUG
+log_color: False
+
+gluster:
+    smb_share_options:
+        group: "metadata-cache"
+        cache-samba-metadata: "on"
+
+servers:
+{% for host in groups['gluster_nodes'][1:4] %}
+    - {{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}
+{%  endfor %}
+
+clients:
+{% for host in groups['gluster_nodes'][5] %}
+    - {{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}
+{%  endfor %}
+
+servers_info:
+{% for host in groups['gluster_nodes'][1:4] %}
+    {{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}: &server{{ loop.index }}
+        host: {{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}
+        devices: ["/dev/mapper/group0-vol0", "/dev/mapper/group1-vol1", "/dev/mapper/group2-vol2", "/dev/mapper/group3-vol3"]
+        brick_root: "/mnt"
+{%  endfor %}
+
+clients_info:
+{% for host in groups['gluster_nodes'][5] %}
+    {{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}: &client{{ loop.index }}
+        host: {{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}
+{% endfor %}

--- a/scripts/gluster-block/jenkins-job-block.yml
+++ b/scripts/gluster-block/jenkins-job-block.yml
@@ -1,0 +1,61 @@
+
+- job:
+    name: gluster_block_glusto
+    node: gluster
+    description: Run the functional tests from glusto-tests
+    project-type: freestyle
+    concurrent: true
+
+    parameters:
+    - string:
+        default: '6'
+        description: Number of nodes for this test
+        name: NODE_COUNT
+    - bool:
+        default: True
+        description: Exit on first failure
+        name: EXIT_ON_FAIL
+    - string:
+        default: 'master'
+        description: Gerrit ref for Glusto. For 12345/6 use 45/12345/6. Two fixed names you can use - stable and master.
+        name: GERRIT_REF
+
+    scm:
+    - git:
+        url: https://github.com/gluster/centosci.git
+        branches:
+        - origin/master
+
+    properties:
+    - build-discarder:
+        days-to-keep: 7
+        artifact-days-to-keep: 7
+
+    builders:
+    - shell: !include-raw: scripts/common/get-node-to-ansible.sh
+    - shell: !include-raw: scripts/gluster-block/run-glusto-main.sh
+    - shell: !include-raw: scripts/gluster-block/get-glusto-logs.sh
+
+    publishers:
+    - archive:
+        artifacts: 'glustomain.log'
+        allow-empty: true
+    - archive:
+        artifacts: 'gluster-logs.gz'
+        allow-empty: true
+    - post-tasks:
+        - matches:
+            - log-text: Build was aborted
+          script:
+            !include-raw: scripts/glusto/get-glusto-logs.sh
+        - matches:
+            # "Building remotely" should always be in the build console output
+            - log-text: Building remotely
+          script:
+            !include-raw: scripts/common/return-node.sh
+
+
+    wrappers:
+    - ansicolor:
+        colormap: xterm
+    - timestamps

--- a/scripts/gluster-block/run_glusto_main.sh
+++ b/scripts/gluster-block/run_glusto_main.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Run ansible script to setup everything
+# Get master IP
+host=$(grep ansible_host hosts | head -n 1 | awk '{split($2, a, "="); print a[2]}')
+
+set -x
+
+GLUSTO_WORKSPACE="$WORKSPACE"
+export GLUSTO_WORKSPACE
+# Retry Ansible runs thrice
+MAX=3
+RETRY=0
+while [ $RETRY -lt $MAX ];
+do
+    ANSIBLE_HOST_KEY_CHECKING=False "$HOME/env/bin/ansible-playbook" -i hosts scripts/gluster-block/setup-gluster-block-glusto.yml
+    #ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i hosts "$WORKSPACE/setup_glusto-on-nodes-local.yml"
+    RETURN_CODE=$?
+    if [ $RETURN_CODE -eq 0 ]; then
+        break
+    fi
+    RETRY=$((RETRY+1))
+done
+
+scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no scripts/gluster-block/run_glusto_on_host.sh "root@${host}:run_glusto_on_host.sh"
+ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "root@$host" EXIT_ON_FAIL="$EXIT_ON_FAIL" ./run_glusto_on_host.sh
+JENKINS_STATUS=$?
+
+source $GLUSTO_WORKSPACE/scripts/glusto/get-glusto-logs.sh
+exit $JENKINS_STATUS

--- a/scripts/gluster-block/run_glusto_on_host.sh
+++ b/scripts/gluster-block/run_glusto_on_host.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+
+cd /root/gluster-block/tests
+SETX=""
+if [ $EXIT_ON_FAIL == True ]
+    then
+    SETX="-x"
+fi
+
+glusto -c ../../gluster_tests_config.yml --pytest="-v $SETX glusto/* "
+

--- a/scripts/gluster-block/setup-gluster-block-glusto.yml
+++ b/scripts/gluster-block/setup-gluster-block-glusto.yml
@@ -1,0 +1,356 @@
+# vim:ft=ansible:
+---
+
+#Generate a ssh key pair
+- hosts: localhost
+  tasks:
+  - name: Create an ssh keypair
+    shell: ssh-keygen -b 2048 -t rsa -f $GLUSTO_WORKSPACE/glusto -q -N ""
+    args:
+      creates: "{{ lookup('env', 'GLUSTO_WORKSPACE')}}/glusto"
+
+#Copy the public key to all nodes other than the host node
+- hosts: gluster_nodes[1:]
+  tasks:
+  - name: Set workspace
+    set_fact:
+      workspace: "{{ lookup('env', 'GLUSTO_WORKSPACE') }}"
+
+  - name: Add entries to authorized_keys
+    authorized_key: user=root key="{{ lookup('file', workspace + '/glusto.pub')}}"
+
+#Install epel 
+- hosts: gluster_nodes
+  tasks:
+  - name: Setup EPEL
+    yum: name=epel-release state=installed
+
+
+# Server and client tasks
+- hosts: gluster_nodes[1:5]
+  tasks:
+  - name: Disable ipv6 in eth0 config
+    lineinfile:
+      dest: /etc/sysconfig/network-scripts/ifcfg-eth0
+      regexp: ^IPV6INIT=
+      line: IPV6INIT=no
+
+  - name: Disable ipv6 in network config
+    lineinfile:
+      dest: /etc/sysconfig/network
+      regexp: ^NETWORKING_IPV6=
+      line: NETWORKING_IPV6=no
+
+  - name: Disable ipv6 in sysctl
+    sysctl:
+      name: "{{ item }}"
+      value: 1
+      state: present
+      reload: yes
+    with_items:
+    - net.ipv6.conf.all.disable_ipv6
+    - net.ipv6.conf.default.disable_ipv6
+
+  - name: Stop Firewall
+    service: name=firewalld state=stopped
+
+  - name: Flush iptables
+    command: "iptables -F"
+
+  - name: Flush iptables
+    command: "iptables -X"
+
+  - name: Setup arequal repo
+    yum_repository:
+      name: nigelbabu-arequal
+      description: Copr repo for arequal
+      baseurl: https://copr-be.cloud.fedoraproject.org/results/nigelbabu/arequal/epel-7-$basearch/
+      gpgcheck: yes
+      gpgkey: https://copr-be.cloud.fedoraproject.org/results/nigelbabu/arequal/pubkey.gpg
+      repo_gpgcheck: no
+
+  - name: Install dependency packages
+    yum: name={{ item }} state=installed
+    with_items:
+    - nfs-utils
+    - cifs-utils
+    - arequal
+    - rsync
+
+# Set up servers for glusterfs
+- hosts: gluster_nodes[1:4]
+  tasks:
+
+  - name: Install dependency packages
+    yum: name={{ item }} state=installed
+    with_items:
+    - libibverbs
+
+  - name: Setup the repo
+    yum_repository:
+      name: gluster_nightly
+      description: The nightly repo for Gluster
+      #baseurl: "{{ 'http://' + hostvars[groups['gluster_nodes'][0]]['ansible_eth0']['ipv4']['address'] + '/RPMS/' }}"
+      baseurl: http://artifacts.ci.centos.org/gluster/nightly/master/$releasever/$basearch
+      gpgcheck: no
+      repo_gpgcheck: no
+
+  - name: Install gluster
+    yum: name={{ item }} state=installed
+    with_items:
+    - glusterfs-server
+    - glusterfs-cli
+    - glusterfs-debuginfo
+
+  - name: Install gluster GNFS package
+    yum: name=glusterfs-gnfs state=installed
+    ignore_errors: True
+
+  - name: Allocate space to a file
+    command: "fallocate -l 50G /var/{{item}}"
+    args:
+      creates: "/var/{{item}}"
+    with_items:
+    - data0
+    - data1
+    - data2
+    - data3
+
+  - name: Associate loopback device to file
+    command: "losetup -f /var/{{item.1}}"
+    args:
+      creates: "/dev/{{item.0}}"
+    with_together:
+    - ['loop0', 'loop1', 'loop2', 'loop3']
+    - ['data0', 'data1', 'data2', 'data3']
+    loop_control:
+      pause: 2
+    ignore_errors: True
+
+  - name: Create physical volume
+    command: "pvcreate /dev/{{item}}"
+    with_items:
+    - loop0
+    - loop1
+    - loop2
+    - loop3
+    loop_control:
+      pause: 2
+    ignore_errors: True
+
+  - name: Create volume groups
+    lvg:
+      vg: "{{item.0}}"
+      pvs: "/dev/{{item.1}}"
+    ignore_errors: yes
+    with_together:
+    - ['group0', 'group1', 'group2', 'group3']
+    - ['loop0', 'loop1', 'loop2', 'loop3']
+
+  - name: Create thin pool
+    command: "lvcreate -L 45G -T {{item}}/pool"
+    args:
+      creates: "/dev/{{item}}"
+    ignore_errors: yes
+    with_items:
+    - group0
+    - group1
+    - group2
+    - group3
+
+  - name: Create thin volume
+    command: "lvcreate -V 45G -T {{item.0}}/pool -n {{item.1}}"
+    args:
+      creates: "/dev/{{item.0}}/{{item.1}}"
+    ignore_errors: yes
+    with_together:
+    - ['group0', 'group1', 'group2', 'group3']
+    - ['vol0', 'vol1', 'vol2', 'vol3']
+
+  - name: Format the volumes
+    command: "mkfs.xfs /dev/{{item.0}}/{{item.1}}"
+    ignore_errors: yes
+    with_together:
+    - ['group0', 'group1', 'group2', 'group3']
+    - ['vol0', 'vol1', 'vol2', 'vol3']
+
+  - name: Mount the bricks
+    mount: name="/mnt/{{item.0}}" src="/dev/{{item.1}}" state=mounted fstype=xfs
+    with_together:
+    - ['vol0', 'vol1', 'vol2', 'vol3']
+    - ['group0/vol0', 'group1/vol1', 'group2/vol2', 'group3/vol3']
+
+  - name: Start Gluster Daemon
+    service: name=glusterd state=started
+
+  - name: Status rpcbind
+    service: name=rpcbind state=started
+
+
+#Set up gluster-block and related packages on servers
+- hosts: gluster_nodes[1:4]
+  tasks:
+  - name: Install dependency packages
+    yum: name={{ item }} state=installed
+    with_items:
+    - git
+    - libtool
+    - libuuid-devel
+    - python-gobject
+    - glusterfs-api-devel
+    - automake
+    - autoconf
+    - gcc
+    - glib2-devel
+    - "*kmod*"
+    - "libnl3*"
+    - zlib-devel
+    - cmake
+
+  - name: Clone configshell-fb repo
+    git:
+        repo: https://github.com/open-iscsi/configshell-fb
+        dest: /root/configshell-fb
+
+  - name: Install configshell-fb repo
+    command: "python setup.py install chdir=/root/configshell-fb"
+
+  - name: Clone rtslib repo
+    git:
+        repo: https://github.com/open-iscsi/rtslib-fb
+        dest: /root/rtslib-fb
+
+  - name: Install rtslib
+    command: "python setup.py install chdir=/root/rtslib-fb"
+
+  - name: Clone targetcli-fb repo
+    git:
+        repo: https://github.com/open-iscsi/targetcli-fb
+        dest: /root/targetcli-fb
+
+  - name: Install targetcli-fb
+    command: "python setup.py install chdir=/root/targetcli-fb"
+
+  - name: Clone tcmu-runner repo
+    git:
+        repo: https://github.com/open-iscsi/tcmu-runner
+        dest: /root/tcmu-runner
+
+  - name: Install tcmu-runner
+    command: 'chdir=/root/tcmu-runner {{ item }}'
+    with_items:
+    -  sed -i "s/linux\/uio.h/sys\/uio.h/" target_core_user_local.h
+    -  cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -Dwith-rbd=false -Dwith-qcow=false -DSUPPORT_SYSTEMD=ON -DCMAKE_BUILD_TYPE=Debug
+    -  make install
+
+  - name: Create /etc/target if it does not exist 
+    command: 'if [ ! -d "/etc/target" ]; then mkdir /etc/target ; fi'
+
+  - name: Copy target.service
+    command: 'chdir=/root/rtslib-fb {{ item }}'
+    with_items:
+    -   cp systemd/target.service /usr/lib/systemd/system/
+
+  - name: Clone gluster-block repo
+    git:
+        repo: https://github.com/gluster/gluster-block
+        dest: /root/gluster-block
+
+
+  - name: Install gluster-block
+    command: 'chdir=/root/gluster-block {{ item }}'
+    with_items:
+    -  ./autogen.sh
+    -  ./configure
+    -  make
+    -  make install
+
+  - name: Start gluster-block Daemon
+    service: name=gluster-blockd state=started
+
+# Setup packages for gluster-block on client
+- hosts: gluster_nodes[5]
+  tasks:
+  - name: Install dependency packages
+    yum: name={{ item }} state=installed
+    with_items:
+    - iscsi-initiator-utils 
+    - device-mapper-multipath
+
+  - name: Start iscsi Daemon
+    service: name=iscsid state=started
+
+  - name: set multipath
+    command: "modprobe dm_multipath"
+
+  - name: Set multipath
+    command:  "mpathconf --enable"
+
+  - name: append the multipath.conf file
+    blockinfile:
+        dest: /etc/multipath.conf
+        block: |
+            # LIO iSCSI
+            devices {
+                device {
+                    vendor "LIO-ORG"
+                    user_friendly_names "yes" # names like mpatha
+                    path_grouping_policy "failover" # one path per group
+                    path_selector "round-robin 0"
+                    failback immediate
+                    path_checker "tur"
+                    prio "const"
+                    no_path_retry 120
+                    rr_weight "uniform"
+                }
+            }
+        backup: yes
+
+  - name: Restart multipath daemon
+    service: name=multipathd state=restarted
+
+#peer probe all nodes
+- hosts: gluster_nodes[1]
+  tasks:
+  - name: Peer probe all nodes
+    command: "gluster peer probe {{hostvars[item]['ansible_eth0']['ipv4']['address']}}"
+    with_items: "{{groups['gluster_nodes'][2:4]}}"
+
+  - name: Setup SELinux in permissive mode
+    selinux: policy=targeted state=enforcing
+
+
+# Set up glusto packages on the host node
+- hosts: gluster_nodes[0]
+  tasks:
+  - name: Copy ssh key
+    copy: src="{{ lookup('env', 'GLUSTO_WORKSPACE') }}/glusto" dest=/root/.ssh/id_rsa mode=600
+
+  - name: Install git and pip
+    yum: name="{{item}}" state=present
+    with_items:
+    - git
+    - python-pip
+
+  - name: Install Glusto
+    pip: name=' git+git://github.com/loadtheaccumulator/glusto.git' editable=false
+
+  - name: Clone the glusto-tests repo
+    git:
+        repo: git://review.gluster.org/glusto-tests.git
+        dest: /root/glusto-tests
+
+  - name: Install glustolibs
+    command: "python setup.py develop chdir=/root/glusto-tests/{{item}}"
+    with_items:
+    - glustolibs-gluster
+    - glustolibs-io
+    - glustolibs-misc
+
+  - name: Clone gluster-block repo
+    git:
+        repo: https://github.com/gluster/gluster-block
+        dest: /root/gluster-block
+
+  - name: Create the config file
+    template: src="{{ lookup('env', 'GLUSTO_WORKSPACE') }}/scripts/gluster-block/gluster_block_glusto_tests_config.yml.j2" dest=/root/gluster_tests_config.yml


### PR DESCRIPTION
This patch series adds the files needed to run glusto based tests(not per patch) on centos CI.
For now, I am assuming that the gluster-block related glusto libs are there in the glusto-tests repo and the test cases are in gluster-block repo. Therefore, the tests are run accordingly.

The same files can be modified for regression testing(triggered from Github PR) and glusto per patch testing. I will be sending a PR for that too.
[Fixes: bz#1598326](https://bugzilla.redhat.com/show_bug.cgi?id=1598326)
Signed-off-by: Bhumika Goyal <bgoyal@redhat.com>