### PR TITLE
get-node: add error checking for failing cico

### DIFF
--- a/scripts/common/get-node.sh
+++ b/scripts/common/get-node.sh
@@ -10,6 +10,18 @@ rm -rf $ANSIBLE_HOSTS
 
 # Get nodes
 nodes=$(cico -q node get --count ${NODE_COUNT} --column hostname --column ip_address --column comment -f value)
+cico_ret=$?
+
+# Fail in case cico returned an error, or no nodes at all
+if [ ${cico_ret} -ne 0 ]
+then
+    echo "cico returned an error (${cico_ret})"
+    exit 2
+elif [ -z "${nodes}" ]
+then
+    echo "cico failed to return any systems"
+    exit 2
+fi
 
 # Write nodes to inventory file and persist the SSID separately for simplicity
 touch ${SSID_FILE}


### PR DESCRIPTION
We have seen occasions where the heketi-functional job failed before any
test got executed. This results in failures like:

    [gluster_heketi-functional] $ /bin/sh -xe /tmp/jenkins5285185003978476870.sh
    + ./bootstrap.sh heketi-centos-ci-tests.sh ghprbPullId=1281
    ++ basename heketi-centos-ci-tests.sh
    + EXEC_BIN=heketi-centos-ci-tests.sh
    ++ cat /home/gluster/workspace/gluster_heketi-functional/hosts
    cat: /home/gluster/workspace/gluster_heketi-functional/hosts: No such file or directory
    + scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no heketi-centos-ci-tests.sh root@:heketi-centos-ci-tests.sh
    ssh: Could not resolve hostname : Name or service not known

Because the 'hosts' file is missing, the hostname of the scp target is
empty.

This change adds a few simple checks for the 'cico' result, and aborts
testing early in case 'cico' returns a failure.

Signed-off-by: Niels de Vos <ndevos@redhat.com>