### PR TITLE
Fix syntax error in GlusterFS nightly-builds.sh script

### DIFF
--- a/scripts/nightly-builds/nightly-builds.sh
+++ b/scripts/nightly-builds/nightly-builds.sh
@@ -69,6 +69,7 @@ case "${CENTOS_VERSION}/${GIT_VERSION}" in
     6/4*)
         # CentOS-6 does not support server builds from Gluster 4.0 onwards
         MOCK_RPM_OPTS='--without=server'
+        ;;
     *)
         # gnfs is not enabled by default, but our regression tests depend on it
         MOCK_RPM_OPTS='--with=gnfs'


### PR DESCRIPTION
@kshlm reported an issue where nightly builds fail with the following error:

```
     am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)
if test -d "glusterfs-3.12.13"; then find "glusterfs-3.12.13" -type d ! -perm -200 -exec chmod u+w {} ';' && rm -rf "glusterfs-3.12.13" || { sleep 5 && rm -rf "glusterfs-3.12.13"; }; else :; fi
./nightly-builds.sh: line 72: syntax error near unexpected token `)'
Build step 'Execute shell' marked build as failure
```

It seems the `case` statement did not have the appropriate `;;`.