### PR TITLE
Add GlusterFS release-5 & release-6 branch to tests

### DIFF
--- a/jobs/build-rpms.yml
+++ b/jobs/build-rpms.yml
@@ -21,8 +21,8 @@
         choices:
         - master
         - release-3.12
-        - release-3.10
-        - release-4.0
+        - release-4.1
+        - release-5
         description: Gluster branch to build RPMs
         name: GERRIT_BRANCH
     - choice:

--- a/jobs/build-rpms.yml
+++ b/jobs/build-rpms.yml
@@ -20,9 +20,9 @@
     - choice:
         choices:
         - master
-        - release-3.12
         - release-4.1
         - release-5
+        - release-6
         description: Gluster branch to build RPMs
         name: GERRIT_BRANCH
     - choice:

--- a/jobs/nightly-rpm-builds.yml
+++ b/jobs/nightly-rpm-builds.yml
@@ -31,24 +31,6 @@
         - project: gluster_build-rpms
           block: false
           predefined-parameters:
-            GERRIT_BRANCH=release-3.12
-
-            CENTOS_VERSION=7
-
-            CENTOS_ARCH=x86_64
-    - trigger-builds:
-        - project: gluster_build-rpms
-          block: false
-          predefined-parameters:
-            GERRIT_BRANCH=release-3.12
-
-            CENTOS_VERSION=6
-
-            CENTOS_ARCH=x86_64
-    - trigger-builds:
-        - project: gluster_build-rpms
-          block: false
-          predefined-parameters:
             GERRIT_BRANCH=release-4.1
 
             CENTOS_VERSION=6
@@ -79,5 +61,23 @@
             GERRIT_BRANCH=release-5
 
             CENTOS_VERSION=7
+
+            CENTOS_ARCH=x86_64
+    - trigger-builds:
+        - project: gluster_build-rpms
+          block: false
+          predefined-parameters:
+            GERRIT_BRANCH=release-6
+
+            CENTOS_VERSION=7
+
+            CENTOS_ARCH=x86_64
+    - trigger-builds:
+        - project: gluster_build-rpms
+          block: false
+          predefined-parameters:
+            GERRIT_BRANCH=release-6
+
+            CENTOS_VERSION=6
 
             CENTOS_ARCH=x86_64

--- a/jobs/nightly-rpm-builds.yml
+++ b/jobs/nightly-rpm-builds.yml
@@ -63,3 +63,21 @@
             CENTOS_VERSION=7
 
             CENTOS_ARCH=x86_64
+    - trigger-builds:
+        - project: gluster_build-rpms
+          block: false
+          predefined-parameters:
+            GERRIT_BRANCH=release-5
+
+            CENTOS_VERSION=6
+
+            CENTOS_ARCH=x86_64
+    - trigger-builds:
+        - project: gluster_build-rpms
+          block: false
+          predefined-parameters:
+            GERRIT_BRANCH=release-5
+
+            CENTOS_VERSION=7
+
+            CENTOS_ARCH=x86_64

--- a/jobs/scripts/nightly-builds/nightly-builds.sh
+++ b/jobs/scripts/nightly-builds/nightly-builds.sh
@@ -66,8 +66,9 @@ SRPM=$(rpmbuild --define 'dist .autobuild' --define "_srcrpmdir ${PWD}" \
 
 MOCK_RPM_OPTS=''
 case "${CENTOS_VERSION}/${GIT_VERSION}" in
-    6/4*)
+    6/4*|6/5*)
         # CentOS-6 does not support server builds from Gluster 4.0 onwards
+	# TODO: once glusterfs-3.x is obsolete, always set this for CentOS-6
         MOCK_RPM_OPTS='--without=server'
         ;;
     *)


### PR DESCRIPTION
GlusterFS 5 has been branched. Add it to the tests for nightly builds.