### PR TITLE
nightly-build: use the storage-gluster-common buildroot from CentOS CBS

### DIFF
--- a/jobs/scripts/nightly-builds/nightly-builds.sh
+++ b/jobs/scripts/nightly-builds/nightly-builds.sh
@@ -9,6 +9,10 @@ artifact()
 # if anything fails, we'll abort
 set -e
 
+[ -n "${GERRIT_BRANCH}" ] || ( echo "environment variable GERRIT_BRANCH is required"; exit 1 )
+[ -n "${CENTOS_VERSION}" ] || ( echo "environment variable CENTOS_VERSION is required"; exit 1 )
+[ -n "${CENTOS_ARCH}" ] || ( echo "environment variable CENTOS_ARCH is required"; exit 1 )
+
 # install basic dependencies for building the tarball and srpm
 yum -y install git autoconf automake gcc libtool bison flex make rpm-build mock createrepo_c centos-packager
 # gluster repositories contain additional -devel packages


### PR DESCRIPTION
Using an EPEL buildroot for CentOS packages is not correct. This can
cause problems when packages are not matching in the EPEL and CentOS
repositories.

Use the Koji profile 'cbs' provided by the centos-packager RPM to fetch
the mock-config from the CentOS CBS. Use this config to rebuild the
src.rpm so the resulting packages have correct dependencies.

Updates: #22
Signed-off-by: Niels de Vos <ndevos@redhat.com>