### PR TITLE
heketi-functional: increase timeout to 3 hours

### DIFF
--- a/heketi-functional.yml
+++ b/heketi-functional.yml
@@ -64,6 +64,6 @@
         colormap: xterm
     - timestamps
     - timeout:
-        # current build takes more than 75 minutes, this gives some slack
-        timeout: 120
+        # current build takes more than 2 hours, this gives some slack
+        timeout: 180
         abort: true


### PR DESCRIPTION
This is a short term fix to deal with the fact that heketi functional tests are regularly timing out now, mainly due to the increased number of functional tests we've added. A longer term project to make the functional tests faster is needed but for now we're just going to increase the timeout.