### PR TITLE
csi-driver: run smoke test on the master branch after merging changes

### DIFF
--- a/jobs/csi-driver-smoke.yml
+++ b/jobs/csi-driver-smoke.yml
@@ -42,3 +42,40 @@
     - ansicolor:
         colormap: xterm
     - timestamps
+
+- job:
+    name: gluster_csi-driver-master
+    node: gluster
+    description: Smoke test for merged changes in the gluster-csi-driver master branch
+    project-type: freestyle
+    concurrent: true
+
+    scm:
+    - git:
+        url: https://github.com/gluster/centosci.git
+        branches:
+        - origin/master
+
+    properties:
+    - github:
+        url: https://github.com/gluster/gluster-csi-driver/
+
+    triggers:
+    - github
+
+    builders:
+    - shell: !include-raw: scripts/common/get-node.sh
+    - shell: jobs/scripts/common/bootstrap.sh $WORKSPACE/jobs/scripts/csi-driver-smoke/run-test.sh
+
+    publishers:
+    - post-tasks:
+        - matches:
+            # "Building remotely" should always be in the build console output
+            - log-text: Building remotely
+          script:
+            !include-raw: scripts/common/return-node.sh
+
+    wrappers:
+    - ansicolor:
+        colormap: xterm
+    - timestamps


### PR DESCRIPTION
The badge on the gluster-csi-driver project reflects the last run of the
smoke test. These tests are run against pull-requests, and not the
actual merged changes in master.

Introduce a 2nd job that runs the same smoke tests, but only once there
are pushed changes in the master branch. This uses the Jenkins GitHub
plugin as explained on the CentOS Wiki. As the page explains, it is
required to configure the GitHub project with a Webhook pointing to the
CentOS CI as well.

Once this change has been merged, the image in the README can be updated
to https://ci.centos.org/view/Gluster/job/gluster_csi-driver-master

URL: https://wiki.centos.org/QaWiki/CI/GithubIntegration
Updates: gluster/gluster-csi-driver#96