### PR TITLE
nightly-builds: install latest centos-release-gluster package

### DIFF
--- a/jobs/scripts/nightly-builds/nightly-builds.sh
+++ b/jobs/scripts/nightly-builds/nightly-builds.sh
@@ -12,7 +12,7 @@ set -e
 # install basic dependencies for building the tarball and srpm
 yum -y install git autoconf automake gcc libtool bison flex make rpm-build mock createrepo_c
 # gluster repositories contain additional -devel packages
-yum -y install centos-release-gluster
+yum -y install centos-release-storage-common centos-release-gluster
 yum -y install python-devel libaio-devel librdmacm-devel libattr-devel libxml2-devel readline-devel openssl-devel libibverbs-devel fuse-devel glib2-devel userspace-rcu-devel libacl-devel sqlite-devel libuuid-devel
 
 # clone the repository, github is faster than our Gerrit


### PR DESCRIPTION
With the update to CentOS 7.1810 it seems that yum changed behaviour a
little. For some (unclear at the moment) reason yum decides to install
centos-release-gluster-legacy instead of centos-release-gluster5.

By installing centos-release-storage-common *before* requesting to
install centos-release-gluster, yum picks the right version.

This is a workaround as installing centos-release-gluster on a cleanly
installed system should get the latest maintained Gluster release.