### PR TITLE
block: install libtcmu too, along with tcmu-runner

### DIFF
--- a/jobs/scripts/gluster-block/gluster-block-basic.sh
+++ b/jobs/scripts/gluster-block/gluster-block-basic.sh
@@ -38,7 +38,11 @@ clone_and_build_rpms()
     pushd tcmu-runner
     cd extra/
     bash make_runnerrpms.sh --without rbd --without qcow --without zbc --without fbo
-    rpm -i rpmbuild/RPMS/x86_64/tcmu-runner*.rpm
+
+    # install tcmu runner RPMs so gluster-block dependency can be satisfied
+    # notice that tcmu-runner now depends on libtcmu too, which gets built
+    # separately
+    rpm -i rpmbuild/RPMS/x86_64/*.rpm
     popd
 
     rm -rf gluster-block/


### PR DESCRIPTION
Fix the below error which is stopping the script.

error: Failed dependencies:
	libtcmu = 1.4.0.83.g9d8a7e9-0.el7 is needed by tcmu-runner-1.4.0.83.g9d8a7e9-0.el7.x86_64
	libtcmu.so.2()(64bit) is needed by tcmu-runner-1.4.0.83.g9d8a7e9-0.el7.x86_64

Signed-off-by: Amar Tumballi <amarts@redhat.com>