### PR TITLE
gluster-block/nightly: place repo metadata with the RPMs

### DIFF
--- a/jobs/scripts/gluster-block/gluster-block-basic.sh
+++ b/jobs/scripts/gluster-block/gluster-block-basic.sh
@@ -64,7 +64,7 @@ push_rpms_to_repo()
     cp -a tcmu-runner/extra/rpmbuild/RPMS/x86_64/* ${RPMDIR}
     cp -a gluster-block/build/rpmbuild/RPMS/x86_64/* ${RPMDIR}
 
-    pushd "$TARGET_DIR"
+    pushd "${RPMDIR}"
     createrepo_c .
     popd
 


### PR DESCRIPTION
Using the gluster-block.repo file fails to fetch the repository metadata
and errors out like this:

    http://artifacts.ci.centos.org/gluster/gluster-block-nightly/master/7/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 404 - Not Found

It seems the repodata is not generated at the right location. With this
change the repodata will be located alongside the RPMs, just as what is
configured in the .repo file.

Closes: #52
Signed-off-by: Niels de Vos <ndevos@redhat.com>