### PR TITLE
nightly-builds: fix shallow cloning of git repository for non-master branches

### DIFF
--- a/jobs/scripts/nightly-builds/nightly-builds.sh
+++ b/jobs/scripts/nightly-builds/nightly-builds.sh
@@ -17,11 +17,8 @@ yum -y install python-devel libaio-devel librdmacm-devel libattr-devel libxml2-d
 
 # clone the repository, github is faster than our Gerrit
 #git clone https://review.gluster.org/glusterfs
-git clone --depth 1 https://github.com/gluster/glusterfs
+git clone --depth 1 --branch ${GERRIT_BRANCH} https://github.com/gluster/glusterfs
 cd glusterfs/
-
-# switch to the branch we want to build
-git checkout ${GERRIT_BRANCH}
 
 # generate a version based on branch.date.last-commit-hash
 if [ ${GERRIT_BRANCH} = 'master' ]; then


### PR DESCRIPTION
When passing `--depth 1` to `git clone`, only the last commit of the
master branch will be fetched. Changing branches afterwards does not
work, as no other branches have been downloaded.

In order to do nightly builds for non-master branches, the `--branch`
argument to `git clone` is required. With this, it is not needed anymore
to checkout the branch afterwards.

Fixes: b552df317a1 ("git clone with just depth 1 for glusterfs")