### PR TITLE
gluster-blockd: configure without tirpc on CentOS

### DIFF
--- a/jobs/scripts/gluster-block/gluster-block-basic.sh
+++ b/jobs/scripts/gluster-block/gluster-block-basic.sh
@@ -50,7 +50,7 @@ clone_and_build_rpms()
 
     pushd gluster-block
     ./autogen.sh
-    ./configure
+    ./configure --enable-tirpc=no
     make rpms
     popd
 }


### PR DESCRIPTION
On RHEL and CentOS the libtirpc version is 0.2.4, but it still has
some bugs and could not work well, so just disable it.

More detail please see: gluster/gluster-block#221