### PR TITLE
nightly-builds: create a VERSION file to not need tags in the git repo

### DIFF
--- a/jobs/scripts/nightly-builds/nightly-builds.sh
+++ b/jobs/scripts/nightly-builds/nightly-builds.sh
@@ -31,10 +31,11 @@ else
     VERSION="${GIT_VERSION}.$(date +%Y%m%d).${GIT_HASH}"
 fi
 
-# overload some variables to match the auto-generated version
-if [ -x build-aux/pkg-version ]; then
-    VERSION="$(build-aux/pkg-version --version)"
-fi
+# Because this is a shallow clone, there are no tags in the git repository. It
+# is not possible to use ./build-aux/pkg-version to get a matching version of a
+# release. Create a VERSION file so that ./build-aux/pkg-version will not
+# return any errors.
+echo "${VERSION}" > VERSION
 
 # unique tag to use in git
 TAG="${VERSION}-$(date +%Y%m%d).${GIT_HASH}"


### PR DESCRIPTION
When a git repository is shallow cloned, there are no tags available.
This makes ./build-aux/pkg-version spit out errors instead of a useable
version. Builds will fail with errors like

    fatal: No names found, cannot describe anything.

By creating a VERSION file in the root of the git repository, the
./build-aux/pkg-version will not give any errors and building the
packages should work again.

Updates: #57 #59