### PR TITLE
nightly-builds: VERSION should start with a 'v'

### DIFF
--- a/jobs/scripts/nightly-builds/nightly-builds.sh
+++ b/jobs/scripts/nightly-builds/nightly-builds.sh
@@ -35,7 +35,7 @@ fi
 # is not possible to use ./build-aux/pkg-version to get a matching version of a
 # release. Create a VERSION file so that ./build-aux/pkg-version will not
 # return any errors.
-echo "${VERSION}" > VERSION
+echo "v${VERSION}" > VERSION
 
 # unique tag to use in git
 TAG="${VERSION}-$(date +%Y%m%d).${GIT_HASH}"


### PR DESCRIPTION
The ./build-aux/pkg-version script in the glusterfs repository expects
that the VERSION starts with a 'v'. Without it, teh script is unable to
detect anything useful.