### PR TITLE
nightly-builds: use date of last commit as part of the package version

### DIFF
--- a/jobs/scripts/nightly-builds/nightly-builds.sh
+++ b/jobs/scripts/nightly-builds/nightly-builds.sh
@@ -20,15 +20,17 @@ yum -y install python-devel libaio-devel librdmacm-devel libattr-devel libxml2-d
 git clone --depth 1 --branch ${GERRIT_BRANCH} https://github.com/gluster/glusterfs
 cd glusterfs/
 
-# generate a version based on branch.date.last-commit-hash
+# generate a version based on branch.last-commit-date.last-commit-hash
 if [ ${GERRIT_BRANCH} = 'master' ]; then
     GIT_VERSION=''
     GIT_HASH="$(git log -1 --format=%h)"
-    VERSION="$(date +%Y%m%d).${GIT_HASH}"
+    GIT_DATE="$(git log -1 --format=format:%cd --date=format:%Y%m%d)"
+    VERSION="${GIT_DATE}.${GIT_HASH}"
 else
     GIT_VERSION="$(sed 's/.*-//' <<< ${GERRIT_BRANCH})"
     GIT_HASH="$(git log -1 --format=%h)"
-    VERSION="${GIT_VERSION}.$(date +%Y%m%d).${GIT_HASH}"
+    GIT_DATE="$(git log -1 --format=format:%cd --date=format:%Y%m%d)"
+    VERSION="${GIT_VERSION}.${GIT_DATE}.${GIT_HASH}"
 fi
 
 # Because this is a shallow clone, there are no tags in the git repository. It


### PR DESCRIPTION
There is no need to have a new version every day (night). By using the
date of the last commit in the package version, the packages will be
built, but the version/release stays the same. This reduces the number
of packages in the repository, and makes it more obvious what changes
were included. The git-hash is still part of the version as well.