### PR TITLE
nightly-builds: older git versions do not support --date=format:...

### DIFF
--- a/jobs/scripts/nightly-builds/nightly-builds.sh
+++ b/jobs/scripts/nightly-builds/nightly-builds.sh
@@ -24,12 +24,12 @@ cd glusterfs/
 if [ ${GERRIT_BRANCH} = 'master' ]; then
     GIT_VERSION=''
     GIT_HASH="$(git log -1 --format=%h)"
-    GIT_DATE="$(git log -1 --format=format:%cd --date=format:%Y%m%d)"
+    GIT_DATE="$(git log -1 --format=format:%cd --date=short | sed 's/-//g')"
     VERSION="${GIT_DATE}.${GIT_HASH}"
 else
     GIT_VERSION="$(sed 's/.*-//' <<< ${GERRIT_BRANCH})"
     GIT_HASH="$(git log -1 --format=%h)"
-    GIT_DATE="$(git log -1 --format=format:%cd --date=format:%Y%m%d)"
+    GIT_DATE="$(git log -1 --format=format:%cd --date=short | sed 's/-//g')"
     VERSION="${GIT_VERSION}.${GIT_DATE}.${GIT_HASH}"
 fi
 


### PR DESCRIPTION
Builds on CentOS 6 and 7 fail with the following error:

    fatal: unknown date format format:%Y%m%d

It seems that older versions of git do not support the --date=format:...
option. Instead use --date=short and strip the dashes with sed.