### PR TITLE
gluster-block: add gperftools-devel as dependency

### DIFF
--- a/jobs/scripts/gluster-block/clang-scan.sh
+++ b/jobs/scripts/gluster-block/clang-scan.sh
@@ -27,7 +27,7 @@ cd ..
 
 git clone https://github.com/open-iscsi/tcmu-runner
 cd tcmu-runner
-yum install -y cmake make gcc libnl3 glib2 zlib kmod libnl3-devel glib2-devel zlib-devel kmod-devel
+yum install -y cmake make gcc libnl3 glib2 zlib kmod libnl3-devel glib2-devel zlib-devel kmod-devel gperftools-devel
 cmake -DSUPPORT_SYSTEMD=ON -DCMAKE_INSTALL_PREFIX=/usr -Dwith-rbd=false -Dwith-qcow=false -Dwith-zbc=false -Dwith-fbo=false
 make install
 

--- a/jobs/scripts/gluster-block/gluster-block-basic.sh
+++ b/jobs/scripts/gluster-block/gluster-block-basic.sh
@@ -25,7 +25,7 @@ install_dependency()
     # gluster repositories contain additional -devel packages
     yum -y install centos-release-gluster
     yum -y install libuuid-devel targetcli glusterfs-api-devel
-    yum -y install libnl3-devel glib2-devel zlib-devel kmod-devel
+    yum -y install libnl3-devel glib2-devel zlib-devel kmod-devel gperftools-devel
     yum -y install json-c-devel help2man rpcbind
 }
 

--- a/jobs/scripts/gluster-block/lcov.sh
+++ b/jobs/scripts/gluster-block/lcov.sh
@@ -27,7 +27,7 @@ cd ..
 
 git clone https://github.com/open-iscsi/tcmu-runner
 cd tcmu-runner
-yum install -y cmake make gcc libnl3 glib2 zlib kmod libnl3-devel glib2-devel zlib-devel kmod-devel
+yum install -y cmake make gcc libnl3 glib2 zlib kmod libnl3-devel glib2-devel zlib-devel kmod-devel gperftools-devel
 cmake -DSUPPORT_SYSTEMD=ON -DCMAKE_INSTALL_PREFIX=/usr -Dwith-rbd=false -Dwith-qcow=false -Dwith-zbc=false -Dwith-fbo=false
 make install
 

--- a/jobs/scripts/gluster-block/setup-gluster-block-glusto.yml
+++ b/jobs/scripts/gluster-block/setup-gluster-block-glusto.yml
@@ -205,6 +205,7 @@
     - cmake
     - python-pip
     - json-c-devel
+    - gperftools-devel
 
   - name: Clone configshell-fb repo
     git:


### PR DESCRIPTION
tcmu-runner project uses tcmalloc now.
This memory allocater is part of gperftools, hence we need to install it.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>