### PR TITLE
Adding task to upgrade pip in setup-glusto.yml file.

### DIFF
--- a/jobs/scripts/glusto/setup-glusto.yml
+++ b/jobs/scripts/glusto/setup-glusto.yml
@@ -295,12 +295,15 @@
     copy: src="/home/gluster/.ssh/glusto" dest=/root/.ssh/id_rsa mode=600
 
   - name: Install git and pip
-    yum: name="{{item}}" state=present
+    yum: name="{{item}}" state=latest
     with_items:
     - git
     - python-pip
     - gcc
     - python-devel
+
+  - name: Upgrading pip
+    command: "pip install --upgrade pip"
 
   - name: Set glusto version
     set_fact:


### PR DESCRIPTION
CentosCI is failing to setup glusto as it it unable
to upgrade pip as shown below:
https://ci.centos.org/job/gluster_glusto-patch-check/1472/consoleFull

Adding task to upgrade pip manually:
- name: Upgrading pip
  command: "pip install --upgrade pip"

Signed-off-by: kshithijiyer <kshithij.ki@gmail.com>