### PR TITLE
Adding task to setup-glusto.yml playbook to install crefi.

### DIFF
--- a/jobs/scripts/glusto/setup-glusto.yml
+++ b/jobs/scripts/glusto/setup-glusto.yml
@@ -250,6 +250,11 @@
   - name: Install python-docx
     pip: name=python-docx state=present
 
+  - name: Installing crefi using pip
+    pip:
+      name: crefi
+      state: present
+
 - hosts: gluster_nodes[1]
   tasks:
   - name: Peer probe all nodes


### PR DESCRIPTION
At present we only use a script called file_dir_ops.py in
glusto-tests to run IO. But the issue with file_dir_ops.py
is that it isn't that effective to create files. A better
tool which is often used is Crefi which can be used to create
a varity of fops.
Link to tool is avaliable here:
https://github.com/vijaykumar-koppad/Crefi

Hence to support running crefi in glustolibs I am adding a task
to setup crefi to setup-glusto.yml.

Signed-off-by: kshithijiyer <kshithij.ki@gmail.com>