### PR TITLE
Fixing lookup plugin issues in setup-glusto.yml

### DIFF
--- a/jobs/scripts/glusto/setup-glusto.yml
+++ b/jobs/scripts/glusto/setup-glusto.yml
@@ -44,7 +44,10 @@
       workspace: "{{ lookup('env', 'GLUSTO_WORKSPACE') }}"
 
   - name: Add entries to authorized_keys
-    authorized_key: user=root key="{{ lookup('file', '/home/gluster/.ssh/glusto.pub')}}"
+    authorized_key:
+      user: root
+      state: present
+      key: "{{ lookup('file', '~/.ssh/glusto.pub') }}"
 
 - hosts: gluster_nodes
   tasks:


### PR DESCRIPTION
At present due to the changes in ansible lookup plugin seems to me failing for centos-ci for glusto-test. Modifying the path format in
task "Add entries to authorized_keys" to fix the issue. And also reformatting the task as per the new task structure used in ansible.

From:
```
- name: Add entries to authorized_keys
  authorized_key: user=root key="{{ lookup('file', '/home/gluster/.ssh/glusto.pub')}}"

```
To:
```
- name: Add entries to authorized_keys
  authorized_key:
    user: root
    state: present
    key: "{{ lookup('file', '~/.ssh/glusto.pub') }}"
```

Signed-off-by: kshithijiyer <kshithij.ki@gmail.com>