### PR TITLE
Reverting back to absolute path for glusto.pub

### DIFF
--- a/jobs/scripts/glusto/setup-glusto.yml
+++ b/jobs/scripts/glusto/setup-glusto.yml
@@ -47,7 +47,7 @@
     authorized_key:
       user: root
       state: present
-      key: "{{ lookup('file', '~/.ssh/glusto.pub') }}"
+      key: "{{ lookup('file', '/home/gluster/.ssh/glusto.pub') }}"
 
 - hosts: gluster_nodes
   tasks:


### PR DESCRIPTION
setup-glusto.yml is still failing as shown below:
`
FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'file'. Error was a <class 'ansible.errors.AnsibleError'>, original message: could not locate file in lookup: ~/.ssh/glusto.pub"}
`

So reverting back to `/home/gluster/.ssh/glusto.pub` instead.

Signed-off-by: kshithijiyer <kshithij.ki@gmail.com>