### PR TITLE
Adding task to install numpy.

### DIFF
--- a/jobs/scripts/glusto/setup-glusto.yml
+++ b/jobs/scripts/glusto/setup-glusto.yml
@@ -258,6 +258,11 @@
       name: crefi
       state: present
 
+  - name: Installing numpy using pip
+    pip:
+      name: numpy
+      state: present
+
 - hosts: gluster_nodes[1]
   tasks:
   - name: Peer probe all nodes


### PR DESCRIPTION
We have optimized the script file_dir_ops.py which is executed on clients to generated I/O
to generate more I/O in less time through patch [1]. This enahancement need numpy to be installed on all the clients. Hence I am adding a task to setup-glusto.yml playbook to install numpy on all clients.
Code added:
```
  - name: Installing crefi using pip
    pip:
      name: crefi
      state: present

```
[1] https://review.gluster.org/#/c/glusto-tests/+/23143/

Signed-off-by: kshithijiyer <kshithij.ki@gmail.com>