### PR TITLE
Add task for installing sh on clients

### DIFF
--- a/jobs/scripts/glusto/setup-glusto.yml
+++ b/jobs/scripts/glusto/setup-glusto.yml
@@ -250,18 +250,13 @@
     - pip
     - setuptools
 
-  - name: Install python-docx
-    pip: name=python-docx state=present
-
-  - name: Installing crefi using pip
-    pip:
-      name: crefi
-      state: present
-
-  - name: Installing numpy using pip
-    pip:
-      name: numpy
-      state: present
+  - name: Install python-docx, crefi, numpy and sh.
+    pip: name={{ item }} state=present
+    with_items:
+    - python-docx
+    - crefi
+    - numpy
+    - sh
 
 - hosts: gluster_nodes[1]
   tasks:


### PR DESCRIPTION
To run rsync based workloads on mounted volumes we
have added rsyncs functionality in file_dir_ops.py through
patch [1]. This requires sh module present on clients. Hence
a task has to be added to install sh module using pip in
setup-glusto.yml playbook.

[1] https://review.gluster.org/#/c/glusto-tests/+/18518/

Signed-off-by: kshithijiyer <kshithij.ki@gmail.com>