### PR TITLE
Edit gluster_tests_config.yml.j2 to run fuse and nfs mounts only.

### DIFF
--- a/jobs/scripts/glusto/templates/gluster_tests_config.yml.j2
+++ b/jobs/scripts/glusto/templates/gluster_tests_config.yml.j2
@@ -2,6 +2,7 @@ log_level: DEBUG
 log_color: False
 
 gluster:
+    running_on_mounts: ['glusterfs', 'nfs']
     smb_share_options:
         group: "metadata-cache"
         cache-samba-metadata: "on"


### PR DESCRIPTION
Problem:
We don't have static ip support for the servers which are utilized
in CentOS-CI which doesn't allow us to setup ctdb server due to this
the testcases which have cifs mount_type in runs_on() fail with
the below error:
```
2020-01-02 07:39:21,719 INFO (run) root@172.19.3.97 (cp): smbclient -L localhost -U | grep -i -Fw gluster-testvol_replicated
2020-01-02 07:39:21,719 DEBUG (_get_ssh_connection) Retrieved connection from cache: root@172.19.3.97
2020-01-02 07:39:21,932 INFO (_log_results) RETCODE (root@172.19.3.97): 1
2020-01-02 07:39:21,932 ERROR (share_volume_over_smb) volume 'testvol_replicated' not accessible via SMB/CIFS share
2020-01-02 07:39:21,932 ERROR (setup_volume) Failed to export volume testvol_replicated as SMB Share
```

Solution:
Skip cifs mount type while running testcases in CentOS-CI by
hard coding `running_on_mounts: ['glusterfs', 'nfs']` in
gluster_tests_config.yml.j2 file.

Signed-off-by: kshithijiyer <kshithij.ki@gmail.com>