### PR TITLE
Changing setup-glusto.yml playbook to install glusto with python3 

### DIFF
--- a/jobs/scripts/glusto/setup-glusto.yml
+++ b/jobs/scripts/glusto/setup-glusto.yml
@@ -306,19 +306,20 @@
     yum: name="{{item}}" state=latest
     with_items:
     - git
-    - python-pip
+    - python3
+    - python3-pip
     - gcc
-    - python-devel
+    - python3-devel
 
   - name: Upgrading pip
-    command: "pip install --upgrade pip"
+    command: "pip3 install --upgrade pip"
 
   - name: Set glusto version
     set_fact:
       GERRIT_REFSPEC: "{{ lookup('env', 'GERRIT_REFSPEC') }}"
 
   - name: Install Glusto
-    pip: name=' git+git://github.com/loadtheaccumulator/glusto.git' editable=false
+    command: 'pip3 install git+git://github.com/loadtheaccumulator/glusto.git@python3_port4'
 
   - name: Clone the glusto-tests repo - {{ GERRIT_REFSPEC}}
     git:
@@ -328,7 +329,7 @@
         version: FETCH_HEAD
 
   - name: Install glustolibs
-    command: "python setup.py develop chdir=/root/glusto-tests/{{item}}"
+    command: "python3 setup.py develop chdir=/root/glusto-tests/{{item}}"
     with_items:
     - glustolibs-gluster
     - glustolibs-io


### PR DESCRIPTION
## Problem:
xmlrunner  is no longer supported with python2, so when we try to run CentOS-CI 
on patches it fails with the below given stack trace:
```
18:29:51 Traceback (most recent call last):
18:29:51   File "/usr/bin/glusto", line 9, in <module>
18:29:51     load_entry_point('glusto==0.62', 'console_scripts', 'glusto')()
18:29:51   File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 378, in load_entry_point
18:29:51     return get_distribution(dist).load_entry_point(group, name)
18:29:51   File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 2566, in load_entry_point
18:29:51     return ep.load()
18:29:51   File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 2260, in load
18:29:51     entry = __import__(self.module_name, globals(),globals(), ['__name__'])
18:29:51   File "/usr/lib/python2.7/site-packages/glusto/main.py", line 22, in <module>
18:29:51     import xmlrunner
18:29:51   File "/usr/lib/python2.7/site-packages/xmlrunner/__init__.py", line 11, in <module>
18:29:51     from .runner import XMLTestRunner
18:29:51   File "/usr/lib/python2.7/site-packages/xmlrunner/runner.py", line 7, in <module>
18:29:51     from .result import _XMLTestResult
18:29:51   File "/usr/lib/python2.7/site-packages/xmlrunner/result.py", line 42, in <module>
18:29:51     for (low, high) in _illegal_unichrs
18:29:51 ValueError: chr() arg not in range(256)
```

## Solution: 
The solution for this is to use glusto and glusto-test with python3 versions of it.
This requires us to change the code as shown below in `setup-glusto.yml`:
```
  - name: Install git and pip
    yum: name="{{item}}" state=latest
    with_items:
    - git
    - python3
    - python3-pip
    - gcc
    - python3-devel

  - name: Upgrading pip
    command: "pip3 install --upgrade pip3"

 .......................................
 .......................................

  - name: Install Glusto
    command: 'pip3 install git+git://github.com/loadtheaccumulator/glusto.git@python3_port4'

 .......................................
 .......................................

  - name: Install glustolibs
    command: "python3 setup.py develop chdir=/root/glusto-tests/{{item}}"
    with_items:
    - glustolibs-gluster
    - glustolibs-io
    - glustolibs-misc
```