### PR TITLE
samba-integration: pass the ghprbTargetBranch variable to the job

### DIFF
--- a/jobs/samba-integration.yml
+++ b/jobs/samba-integration.yml
@@ -48,7 +48,7 @@
     - shell: !include-raw: scripts/common/get-node.sh
       # the samba-integration:centos-ci branch contains a copy of bootstrap.sh
       # from the gluster/centosci repo
-    - shell: ./bootstrap.sh samba-integration-centos-ci-tests.sh "ghprbPullId=${ghprbPullId}"
+    - shell: ./bootstrap.sh samba-integration-centos-ci-tests.sh "ghprbPullId=${ghprbPullId} ghprbTargetBranch=${ghprbTargetBranch}"
 
     publishers:
     - post-tasks:


### PR DESCRIPTION
To be able to rebase the PR to the target branch.

Signed-off-by: Michael Adam <obnox@samba.org>