### PR TITLE
build-rpms: update Jenkins job for testing builds on CentOS 8

### DIFF
--- a/jobs/build-rpms.yml
+++ b/jobs/build-rpms.yml
@@ -27,6 +27,7 @@
         name: GERRIT_BRANCH
     - choice:
         choices:
+        - '8'
         - '7'
         - '6'
         description: CentOS version to build the RPMs

--- a/jobs/build-rpms.yml
+++ b/jobs/build-rpms.yml
@@ -20,7 +20,6 @@
     - choice:
         choices:
         - master
-        - release-4.1
         - release-5
         - release-6
         - release-7

--- a/jobs/build-rpms.yml
+++ b/jobs/build-rpms.yml
@@ -23,6 +23,7 @@
         - release-4.1
         - release-5
         - release-6
+        - release-7
         description: Gluster branch to build RPMs
         name: GERRIT_BRANCH
     - choice:

--- a/jobs/nightly-rpm-builds.yml
+++ b/jobs/nightly-rpm-builds.yml
@@ -31,24 +31,6 @@
         - project: gluster_build-rpms
           block: false
           predefined-parameters:
-            GERRIT_BRANCH=release-4.1
-
-            CENTOS_VERSION=6
-
-            CENTOS_ARCH=x86_64
-    - trigger-builds:
-        - project: gluster_build-rpms
-          block: false
-          predefined-parameters:
-            GERRIT_BRANCH=release-4.1
-
-            CENTOS_VERSION=7
-
-            CENTOS_ARCH=x86_64
-    - trigger-builds:
-        - project: gluster_build-rpms
-          block: false
-          predefined-parameters:
             GERRIT_BRANCH=release-5
 
             CENTOS_VERSION=6


### PR DESCRIPTION
This only adds the option to build for CentOS-8, but does not add the automated trigger in the nightly-rpm-builds job. We'll need to run some manual tests first to see if things function as they should.

GlusterFS 4.1 is end-of-life, so it has been removed as an option too.

Reported-by: Michael Adam (@obnoxxx)