### PR TITLE
samba-integration: only run on PRs to branches master and centos-ci

### DIFF
--- a/jobs/samba-integration.yml
+++ b/jobs/samba-integration.yml
@@ -43,6 +43,9 @@
         - nixpanic
         cron: H/5 * * * *
         status-context: centos-ci
+        white-list-target-branches:
+        - master
+        - centos-ci
 
     builders:
     - shell: !include-raw: scripts/common/get-node.sh


### PR DESCRIPTION
Signed-off-by: Michael Adam <obnox@samba.org>