### PR TITLE
nightly-samba-builds: don't upload artifacts if running on a PR

### DIFF
--- a/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh
+++ b/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh
@@ -45,6 +45,12 @@ fi
 
 make "rpms.centos${CENTOS_VERSION}"
 
+# Don't upload the artifacts if running on a PR.
+if [ -n "${ghprbPullId}" ]
+then
+	exit 0
+fi
+
 pushd "${RESULT_DIR}"
 createrepo_c .
 popd


### PR DESCRIPTION
Signed-off-by: Michael Adam <obnox@samba.org>