### PR TITLE
samba-nightly-builds: remove useless exit at the end

### DIFF
--- a/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh
+++ b/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh
@@ -60,5 +60,3 @@ pushd "${RESULT_BASE}"
 artifact "${REPO_NAME}.repo"
 artifact "${SAMBA_BRANCH}"
 popd
-
-exit ${RET}


### PR DESCRIPTION
The variable RET was not set anyway.
And because of `set -e`, we exit on error, so useless to do error
tracking with a RET variable at this point.

Signed-off-by: Michael Adam <obnox@samba.org>