### PR TITLE
nightly-builds: remove useless exit at the end

### DIFF
--- a/jobs/scripts/nightly-builds/nightly-builds.sh
+++ b/jobs/scripts/nightly-builds/nightly-builds.sh
@@ -109,6 +109,3 @@ pushd /srv/gluster/nightly
 artifact ${REPO_NAME}.repo
 artifact ${GERRIT_BRANCH}
 popd
-
-exit ${RET}
-


### PR DESCRIPTION
The variable RET was not set anyway.
And because of `set -e`, we exit on error, so useless to do error
tracking with a RET variable at this point.

Signed-off-by: Michael Adam <obnox@samba.org>