### PR TITLE
Samba nightly: test rpms install

### DIFF
--- a/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh
+++ b/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh
@@ -23,8 +23,6 @@ set -e
 # epel is needed to get more up-to-date versions of mock and ansible.
 yum -y install epel-release
 yum -y install git make rpm-build mock ansible createrepo_c
-# gluster repositories contain additional -devel packages
-#yum -y install centos-release-storage-common centos-release-gluster
 
 git clone --depth=1 --branch="${BUILD_GIT_BRANCH}" "${BUILD_GIT_REPO}" "${BUILD_GIT_BRANCH}"
 cd "${BUILD_GIT_BRANCH}"

--- a/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh
+++ b/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh
@@ -24,6 +24,47 @@ set -e
 yum -y install epel-release
 yum -y install git make rpm-build mock ansible createrepo_c
 
+
+# Install vagrant/vagrant-libvirt and prerequisites to run the rpm install test.
+
+yum -y install \
+	qemu-kvm \
+	qemu-kvm-tools \
+	qemu-img \
+	make \
+	ansible \
+	libvirt \
+	libvirt-devel
+
+# "Development Tools" and libvirt-devel are needed to run
+# "vagrant plugin install"
+yum -y group install "Development Tools"
+
+
+# We install vagrant directly from upstream hashicorp since
+# the centos/scl vagrant packages are deprecated / broken.
+
+# yum install fails if the package is already installed at the desired
+# version, so we check whether vagrant is already installed at that
+# version. This is important to check when the script is invoked a
+# couple of times in a row to prevent it from failing. As a positive
+# side effect, it also avoids duplicate downloads of the RPM.
+#
+if ! rpm -q vagrant-2.2.7
+then
+	yum -y install https://releases.hashicorp.com/vagrant/2.2.7/vagrant_2.2.7_x86_64.rpm
+fi
+
+vagrant plugin install vagrant-libvirt
+
+# Vagrant needs libvirtd running
+systemctl start libvirtd
+
+# Log the virsh capabilites so that we know the
+# environment in case something goes wrong.
+virsh capabilities
+
+
 git clone --depth=1 --branch="${BUILD_GIT_BRANCH}" "${BUILD_GIT_REPO}" "${BUILD_GIT_BRANCH}"
 cd "${BUILD_GIT_BRANCH}"
 
@@ -42,6 +83,7 @@ then
 fi
 
 make "rpms.centos${CENTOS_VERSION}"
+make "test.rpms.centos${CENTOS_VERSION}"
 
 # Don't upload the artifacts if running on a PR.
 if [ -n "${ghprbPullId}" ]


### PR DESCRIPTION
Testing the samba-nightly-build rpm by installing them in a vm before declaring success.