### PR TITLE
samba-integration: enable PR checking of the tests branch

### DIFF
--- a/jobs/samba-integration.yml
+++ b/jobs/samba-integration.yml
@@ -46,6 +46,7 @@
         white-list-target-branches:
         - master
         - centos-ci
+        - tests
 
     builders:
     - shell: !include-raw: scripts/common/get-node.sh


### PR DESCRIPTION
This is relying on https://github.com/gluster/samba-integration/pull/74

Signed-off-by: Michael Adam <obnox@samba.org>