### PR TITLE
Install git on clients

### DIFF
--- a/jobs/scripts/glusto/setup-glusto.yml
+++ b/jobs/scripts/glusto/setup-glusto.yml
@@ -220,6 +220,7 @@
   - name: Install dependency packages
     yum: name={{ item }} state=installed
     with_items:
+    - git
     - python-pip
     - libxml2-devel
     - libxslt-devel


### PR DESCRIPTION
To run git clone on the gluster volumes, need
git to be installed on the clients.