### PR TITLE
Install libgfapi0 prior to installation of gluster

### DIFF
--- a/jobs/scripts/glusto/setup-glusto.yml
+++ b/jobs/scripts/glusto/setup-glusto.yml
@@ -104,6 +104,7 @@
     - cifs-utils
     - arequal
     - rsync
+    - libgfapi0
 
 # Set up servers
 - hosts: gluster_nodes[1:6]


### PR DESCRIPTION
Problem:
Currently, glusterfs installation on centos-ci is failing with dependency
libgfapi0.
Ref: https://ci.centos.org/job/gluster_glusto-patch-check/2217/console

Fix: 
Installing libgfapi0 prior to installation of glusterfs packages resolves the
issues. I tried it only local machine and it works fine.

Used the fix based on the comment
 https://github.com/gluster/glusterfs/issues/1297#issuecomment-642626533