### PR TITLE
nightly-samba-build: Fix rebasing PR on target branch.

### DIFF
--- a/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh
+++ b/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh
@@ -75,6 +75,9 @@ cd "${BUILD_GIT_BRANCH}"
 # but maybe this was triggered through a PR?
 if [ -n "${ghprbPullId}" ]
 then
+	# We have to fetch the whole target branch to be able to rebase.
+	git fetch --unshallow  origin
+
 	git fetch origin "pull/${ghprbPullId}/head:pr_${ghprbPullId}"
 	git checkout "pr_${ghprbPullId}"
 


### PR DESCRIPTION
Due to the shallow clone, rebasing the PR fails, like here:

https://ci.centos.org/job/gluster_nightly-samba-rpm-builds/108/console

Fix this by unshallowing the clone before doing the rebase.

Signed-off-by: Michael Adam <obnox@samba.org>