### PR TITLE
Add step to install wget to glusto/setup-glusto.yml

### DIFF
--- a/jobs/scripts/glusto/setup-glusto.yml
+++ b/jobs/scripts/glusto/setup-glusto.yml
@@ -250,6 +250,7 @@
     - crefi
     - numpy
     - sh
+    - wget
 
 - hosts: gluster_nodes[1]
   tasks:


### PR DESCRIPTION
Problem:
Patches like [1] which run Linux kernel untar fail on CentOS-CI as wget isn't present by default on the machines with the below error:
```
2020-10-21 09:34:56,781 INFO (run) root@172.19.2.49 (cp): wget https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.4.54.tar.xz
2020-10-21 09:34:56,781 DEBUG (_get_ssh_connection) Retrieved connection from cache: root@172.19.2.49
2020-10-21 09:34:56,833 INFO (_log_results) RETCODE (root@172.19.2.49): 127
2020-10-21 09:34:56,834 INFO (_log_results) STDERR (root@172.19.2.49)...
bash: wget: command not found
```

Solution:
Add task to install wget to setup-glusto.yml

Links:
[1] https://review.gluster.org/#/c/glusto-tests/+/25128/