### PR TITLE
Add glusterfs-geo-replication to Install gluster task

### DIFF
--- a/jobs/scripts/glusto/setup-glusto.yml
+++ b/jobs/scripts/glusto/setup-glusto.yml
@@ -130,6 +130,7 @@
     - glusterfs-server
     - glusterfs-cli
     - glusterfs-debuginfo
+    - glusterfs-geo-replication
 
   - name: Install gluster GNFS package
     yum: name=glusterfs-gnfs state=installed


### PR DESCRIPTION
Problem:
glusterd start command fails due to issue[1], causing the centos-ci jobs to fail.

Fix:
Adding glusterfs-geo-replication to Install gluster task.

Issues:
[1] https://github.com/gluster/glusterfs/issues/1924