### PR TITLE
Add tasks to install pytest version 6.1.2 and py version 1.9.0

### DIFF
--- a/jobs/scripts/glusto/setup-glusto.yml
+++ b/jobs/scripts/glusto/setup-glusto.yml
@@ -309,6 +309,12 @@
   - name: Upgrading pip
     command: "pip3 install --upgrade pip"
 
+  - name: Upgrading pip
+    command: "pip3 install pytest==6.1.2"
+
+  - name: Upgrading pip
+    command: "pip3 install py==1.9.0"
+
   - name: Set glusto version
     set_fact:
       GERRIT_REFSPEC: "{{ lookup('env', 'GERRIT_REFSPEC') }}"

--- a/jobs/scripts/glusto/setup-glusto.yml
+++ b/jobs/scripts/glusto/setup-glusto.yml
@@ -309,10 +309,10 @@
   - name: Upgrading pip
     command: "pip3 install --upgrade pip"
 
-  - name: Upgrading pip
+  - name: Install pytest
     command: "pip3 install pytest==6.1.2"
 
-  - name: Upgrading pip
+  - name: Install pypy
     command: "pip3 install py==1.9.0"
 
   - name: Set glusto version


### PR DESCRIPTION
Problem:
With the pytest version 6.2.1 doClassCleanups() are failing in glusto with the below error:
```
TypeError: _is_error_or_failure_exists() missing 1 required positional argument: 'self'
```

Fix:
Install pytest version 6.1.2 and py version 1.9.0 which can be removed one the issue is fixed in pytest