### PR TITLE
heketi: Increase heketi CI timeout to 5 hrs

### DIFF
--- a/jobs/heketi-functional.yml
+++ b/jobs/heketi-functional.yml
@@ -67,6 +67,6 @@
         colormap: xterm
     - timestamps
     - timeout:
-        # current build takes more than 2 hours, this gives some slack
-        timeout: 180
+        # current build takes more than 3 hours, this gives some slack
+        timeout: 300
         abort: true


### PR DESCRIPTION
Fix build timeout err "Build timed out (after 180 minutes)."

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

![Screenshot from 2021-01-22 13-55-39](https://user-images.githubusercontent.com/22993933/105466059-b6c4fb80-5cb9-11eb-911e-a7841c276d61.png)
