### PR TITLE
Update glusto-patch-check.yml for GitHub workflow

### DIFF
--- a/jobs/glusto-patch-check.yml
+++ b/jobs/glusto-patch-check.yml
@@ -7,12 +7,11 @@
 
     scm:
     - git:
-        url: git://review.gluster.org/glusto-tests.git
-        choosing-strategy: gerrit
-        refspec: $GERRIT_REFSPEC
+        url: https://github.com/gluster/glusto-tests.git
+        refspec: $GITHUB_REFSPEC
         basedir: glusto
         branches:
-        - $GERRIT_BRANCH
+        - $GITHUB_BRANCH
         wipe-workspace: true
     - git:
         url: https://github.com/gluster/centosci.git
@@ -27,17 +26,19 @@
         artifact-days-to-keep: 7
 
     triggers:
-    - gerrit:
-        trigger-on:
-          - comment-added-contains-event:
-              comment-contains-value: "/run tests"
-        server-name: review.gluster.org
-        projects:
-          - project-compare-type: 'PLAIN'
-            project-pattern: 'glusto-tests'
-            branches:
-              - branch-compare-type: 'ANT'
-                branch-pattern: '**'
+    - github-pull-request:
+        cancel-builds-on-update: true
+        allow-whitelist-orgs-as-admins: true
+        org-list:
+          - gluster
+        github-hooks: true
+        only-trigger-phrase: false
+        trigger-phrase: '/run tests'
+        permit-all: true
+        status-context: "Testing: centos-ci-{nodeversion}"
+        started-status: "Running: centos-ci-{nodeversion}"
+        success-status: "OK - centos-ci-{nodeversion}"
+        failure-status: "FAIL - please fix the issues before merging"
 
     parameters:
     - string:
@@ -47,7 +48,7 @@
     - string:
         default: refs/heads/master
         description: Gerrit ref for Glusto. For 12345/6 use 45/12345/6. Two fixed names you can use - stable and master.
-        name: GERRIT_REFSPEC
+        name: GITHUB_REFSPEC
     - string:
         default: ''
         description: The path to the test to run
@@ -55,7 +56,7 @@
     - string:
         default: master
         description: 'Name of the branch you want to build from. We usually build from master'
-        name: GERRIT_BRANCH
+        name: GITHUB_BRANCH
 
     publishers:
     - archive:

--- a/jobs/glusto-patch-check.yml
+++ b/jobs/glusto-patch-check.yml
@@ -17,7 +17,7 @@
         url: https://github.com/gluster/centosci.git
         basedir: centosci
         branches:
-        - origin/master
+        - origin/main
         wipe-workspace: false
 
     properties:

--- a/jobs/glusto-patch-check.yml
+++ b/jobs/glusto-patch-check.yml
@@ -32,7 +32,7 @@
         org-list:
           - gluster
         github-hooks: true
-        only-trigger-phrase: false
+        only-trigger-phrase: true
         trigger-phrase: '/run tests'
         permit-all: true
         status-context: "Testing: centos-ci-{nodeversion}"


### PR DESCRIPTION
We are currently moving glusto-tests from Gerrit(review.gluster.org) to Github workflow for which making changes to glusto-patch-check.yml.

Reference issue:  https://github.com/gluster/glusto-tests/issues/35