### PR TITLE
samba-builds: update status-context of jobs to reflect multiple jobs

### DIFF
--- a/jobs/nightly-samba-rpm-builds.yml
+++ b/jobs/nightly-samba-rpm-builds.yml
@@ -41,7 +41,7 @@
         - spuiuk
         - nixpanic
         cron: H/5 * * * *
-        status-context: centos-ci
+        status-context: 'samba-build-rpms/centos{centos_version}'
         white-list-target-branches:
         - samba-build
 


### PR DESCRIPTION
With the use of job templates, we now have multiple checks to show in PRs.

Signed-off-by: Michael Adam <obnox@redhat.com>