### PR TITLE
release-7 branch is EOL

### DIFF
--- a/jobs/nightly-rpm-builds.yml
+++ b/jobs/nightly-rpm-builds.yml
@@ -63,21 +63,3 @@
             CENTOS_VERSION=8
 
             CENTOS_ARCH=x86_64
-    - trigger-builds:
-        - project: gluster_build-rpms
-          block: false
-          predefined-parameters:
-            GITHUB_BRANCH=release-7
-
-            CENTOS_VERSION=8
-
-            CENTOS_ARCH=x86_64
-    - trigger-builds:
-        - project: gluster_build-rpms
-          block: false
-          predefined-parameters:
-            GITHUB_BRANCH=release-7
-
-            CENTOS_VERSION=7
-
-            CENTOS_ARCH=x86_64


### PR DESCRIPTION
release-7 branch is EOL. 
https://docs.gluster.org/en/latest/release-notes/7.9/
Hence removing the daily builds on release-7.