### PR TITLE
Use `readarray` instead of `read`

### DIFF
--- a/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh
+++ b/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh
@@ -91,7 +91,7 @@ then
 
 	proceed=0
 
-	read -r -d '' -a FILES_CHANGED < <(git diff --name-only origin/"${ghprbTargetBranch}")
+	readarray FILES_CHANGED < <(git diff --name-only origin/"${ghprbTargetBranch}")
 
 	for i in "${FILES_CHANGED[@]}"
 	do


### PR DESCRIPTION
From BASH_BUILTIN(1) man page for `read`:


> The exit status is zero, unless end-of-file is encountered, read times out (in which case the status is greater than 128), a variable assignment error (such as assigning to a readonly variable) occurs, or an invalid file descriptor is supplied as the argument to -u.

So a return value of 1 doesn't mean that execution failed rather encountered EOF. Since successful exit status is a must for us to proceed with script execution, we switch to `readarray` bash builtin instead of `read` to return 0.

Closes #158