### PR TITLE
Define CENTOS_VERSION with a default

### DIFF
--- a/jobs/heketi-functional.yml
+++ b/jobs/heketi-functional.yml
@@ -18,6 +18,10 @@
           through a GitHub pull-request, leave empty for running a test against
           the master branch
         name: ghprbPullId
+    - string:
+        default: '7'
+        description: CentOS version to be installed on host node
+        name: CENTOS_VERSION
 
     scm:
     - git:


### PR DESCRIPTION
With introduction of '--release' option to `cico` command we are bound
to define 'CENTOS_VERSION' variable. See [1] for related change.

[1] 3cbdc28

Thanks to Anoop C S for the fix.

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>