### PR TITLE
Enable building fedora based RPMs

### DIFF
--- a/jobs/nightly-samba-rpm-builds.yml
+++ b/jobs/nightly-samba-rpm-builds.yml
@@ -1,17 +1,19 @@
 - project:
     name: gluster_nightly-samba-rpm-builds
-    centos_version:
-      - '8'
-      - '7'
+    os_version:
+      - 'centos8'
+      - 'centos7'
+      - 'fedora34'
+      - 'fedora33'
     samba_branch:
       - 'master'
       - 'v4-14-test'
       - 'v4-13-test'
     jobs:
-      - 'gluster_samba-build-rpms-centos{centos_version}-{samba_branch}'
+      - 'gluster_samba-build-rpms-{os_version}-{samba_branch}'
 
 - job-template:
-    name: 'gluster_samba-build-rpms-centos{centos_version}-{samba_branch}'
+    name: 'gluster_samba-build-rpms-{os_version}-{samba_branch}'
     node: gluster
     description: Build Samba RPMs.
     project-type: freestyle
@@ -26,8 +28,12 @@
     parameters:
       - string:
           name: CENTOS_VERSION
-          default: '{centos_version}'
-          description: CentOS version to build the RPMs
+          default: '8'
+          description: CentOS version to be installed on host node
+      - string:
+          name: OS_VERSION
+          default: '{os_version}'
+          description: Platform to build the RPMS
       - string:
           name: SAMBA_BRANCH
           default: '{samba_branch}'
@@ -49,7 +55,7 @@
         - spuiuk
         - nixpanic
         cron: H/5 * * * *
-        status-context: 'samba-build-rpms/centos{centos_version}/{samba_branch}'
+        status-context: 'samba-build-rpms/{os_version}/{samba_branch}'
         white-list-target-branches:
         - samba-build
     - pollurl:
@@ -62,7 +68,7 @@
     builders:
     - shell: !include-raw-escape: scripts/common/get-node.sh
     - shell: !include-raw-escape: scripts/common/rsync.sh
-    - shell: jobs/scripts/common/bootstrap.sh $WORKSPACE/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh "ghprbPullId=$ghprbPullId ghprbTargetBranch=$ghprbTargetBranch CENTOS_VERSION=$CENTOS_VERSION SAMBA_BRANCH=$SAMBA_BRANCH"
+    - shell: jobs/scripts/common/bootstrap.sh $WORKSPACE/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh "ghprbPullId=$ghprbPullId ghprbTargetBranch=$ghprbTargetBranch OS_VERSION=$OS_VERSION SAMBA_BRANCH=$SAMBA_BRANCH"
 
     publishers:
     - email-ext:


### PR DESCRIPTION
* Modify configuration to include jobs for building fedora RPMs.
* Introduce an intermediate parent directory to differentiate CentOS and
  Fedora RPMs on CI artifacts.