### PR TITLE
Enable Samba 4.15 test branch builds

### DIFF
--- a/jobs/nightly-samba-rpm-builds.yml
+++ b/jobs/nightly-samba-rpm-builds.yml
@@ -7,8 +7,8 @@
       - 'fedora33'
     samba_branch:
       - 'master'
+      - 'v4-15-test'
       - 'v4-14-test'
-      - 'v4-13-test'
     jobs:
       - 'gluster_samba-build-rpms-{os_version}-{samba_branch}'
 


### PR DESCRIPTION
With v4.15 getting [released](https://wiki.samba.org/index.php/Samba_Release_Planning), v4.13.x series is now **_Security fixes_** only mode and thus we are not interested in having nightly builds from such a very slow-moving target.

Related: https://github.com/gluster/samba-integration/pull/200